### PR TITLE
Fix macos/windows CI

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,7 +2,7 @@ name: linkcheck
 
 # Only build PRs, the main branch, and releases.
 on:
-  #pull_request:
+  pull_request:
   push:
     branches:
       - main
@@ -39,7 +39,6 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
-          pip install numba scipy
           pip install -r requirements-dev.txt
 
       - name: Check links

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,7 +2,7 @@ name: linkcheck
 
 # Only build PRs, the main branch, and releases.
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -114,7 +114,7 @@ jobs:
           conda config --show-sources
           conda config --show
           conda info -a
-          conda install ${{ matrix.case.conda }} pytest pytest-cov pytest-console-scripts coveralls pytest-flake8 setuptools-scm
+          conda install ${{ matrix.case.conda }} pytest pytest-cov pytest-console-scripts coveralls "flake8<5" pytest-flake8 setuptools-scm
 
       - name: Conda list
         shell: bash -l {0}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: linux
 
 # Only build PRs, the main branch, and releases.
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: linux
 
 # Only build PRs, the main branch, and releases.
 on:
-  #pull_request:
+  pull_request:
   push:
     branches:
       - main
@@ -102,13 +102,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           auto-update-conda: true
-          miniconda-version: "latest"
           python-version: ${{ matrix.case.python-version }}
+          miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-          # The following should not be necessary with Mambaforg(?).
-          channels: conda-forge,defaults
-          channel-priority: strict
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -116,9 +113,12 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda config --show-sources
           conda config --show
-          conda install ${{ matrix.case.conda }} pytest pytest-cov pytest-console-scripts coveralls pytest-flake8 setuptools-scm
           conda info -a
-          conda list
+          conda install ${{ matrix.case.conda }} pytest pytest-cov pytest-console-scripts coveralls pytest-flake8 setuptools-scm
+
+      - name: Conda list
+        shell: bash -l {0}
+        run: conda list
 
       - name: Test with pytest
         shell: bash -l {0}

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -73,7 +73,7 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda config --show-sources
           conda config --show
-          conda install numba scipy pytest #pytest-console-scripts pytest-flake8 scooby setuptools-scm
+          conda install numba "scipy<1.9.0" pytest #pytest-console-scripts pytest-flake8 scooby setuptools-scm
           conda info -a
           conda list
 

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -74,6 +74,10 @@ jobs:
           conda config --show-sources
           conda config --show
           conda install numba "scipy<1.9.0" pytest #pytest-console-scripts pytest-flake8 scooby setuptools-scm
+
+      - name: Debug Mamba info
+        shell: bash -l {0}
+        run: |
           conda info -a
           conda list
 

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -74,7 +74,7 @@ jobs:
           conda config --show-sources
           conda config --show
           conda info -a
-          conda install numba "scipy!=1.9.0" pytest pytest-console-scripts pytest-flake8 scooby setuptools-scm
+          conda install numba "scipy!=1.9.0" pytest pytest-console-scripts "flake8<5" pytest-flake8 scooby setuptools-scm
 
       - name: Conda list
         shell: bash -l {0}

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: true #false
       matrix:
-        os: [macos, windows]
-        python: [3.9, ]
+        os: [macos, ] #windows]
+        python: [3.7, 3.8, 3.9, 3.10]
 
     steps:
 
@@ -43,19 +43,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Need to fetch more than the last commit so that setuptools-scm can
-          # create the correct version string. If the number of commits since
-          # the last release is greater than this, the version still be wrong.
-          # Increase if necessary.
-          fetch-depth: 100
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
+        #with:
+        #  # Need to fetch more than the last commit so that setuptools-scm can
+        #  # create the correct version string. If the number of commits since
+        #  # the last release is greater than this, the version still be wrong.
+        #  # Increase if necessary.
+        #  fetch-depth: 100
+        #  # The GitHub token is preserved by default but this job doesn't need
+        #  # to be able to push to GitHub.
+        #  persist-credentials: false
 
       # Need the tags so that setuptools-scm can form a valid version number
-      - name: Fetch git tags
-        run: git fetch origin 'refs/tags/*:refs/tags/*'
+      #- name: Fetch git tags
+      #  run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup miniconda
         # [pin v2.1.1 (2021-04-01)]
@@ -76,7 +76,7 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda config --show-sources
           conda config --show
-          conda install numba scipy pytest pytest-console-scripts pytest-flake8 scooby setuptools-scm
+          conda install numba scipy pytest #pytest-console-scripts pytest-flake8 scooby setuptools-scm
           conda info -a
           conda list
 
@@ -84,4 +84,5 @@ jobs:
         shell: bash -l {0}
         run: |
           python setup.py install
-          pytest --flake8
+          pytest tests/test_transform.py
+          #pytest --flake8

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: true #false
       matrix:
         os: [macos, ] #windows]
-        python: [3.7, 3.8, 3.9, 3.10]
+        python: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
 
@@ -62,13 +62,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@35d1405e78aa3f784fe3ce9a2eb378d5eeb62169
         with:
           auto-update-conda: true
-          miniconda-version: "latest"
           python-version: ${{ matrix.python }}
+          miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-          # The following should not be necessary with Mambaforge(?).
-          channels: conda-forge,defaults
-          channel-priority: strict
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     strategy:
-      fail-fast: true #false
+      fail-fast: false
       matrix:
-        os: [macos, ] #windows]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        os: [macos, windows]
+        python: ["3.9", ]
 
     steps:
 
@@ -43,19 +43,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
-        #with:
-        #  # Need to fetch more than the last commit so that setuptools-scm can
-        #  # create the correct version string. If the number of commits since
-        #  # the last release is greater than this, the version still be wrong.
-        #  # Increase if necessary.
-        #  fetch-depth: 100
-        #  # The GitHub token is preserved by default but this job doesn't need
-        #  # to be able to push to GitHub.
-        #  persist-credentials: false
+        with:
+          # Need to fetch more than the last commit so that setuptools-scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       # Need the tags so that setuptools-scm can form a valid version number
-      #- name: Fetch git tags
-      #  run: git fetch origin 'refs/tags/*:refs/tags/*'
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup miniconda
         # [pin v2.1.1 (2021-04-01)]
@@ -73,17 +73,15 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda config --show-sources
           conda config --show
-          conda install numba "scipy<1.9.0" pytest #pytest-console-scripts pytest-flake8 scooby setuptools-scm
-
-      - name: Debug Mamba info
-        shell: bash -l {0}
-        run: |
           conda info -a
-          conda list
+          conda install numba "scipy!=1.9.0" pytest pytest-console-scripts pytest-flake8 scooby setuptools-scm
+
+      - name: Conda list
+        shell: bash -l {0}
+        run: conda list
 
       - name: Test with pytest
         shell: bash -l {0}
         run: |
           python setup.py install
-          pytest tests/test_transform.py
-          #pytest --flake8
+          pytest --flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ v2.2.x
 """"""
 
 
+latest
+------
+
+- Maintenance
+
+  - Exclude ``scipy!=v1.9.0`` from MacOS/Windows test.
+  - Restrict ``flake8<5`` due to incompatibility with ``pytest-flake8``.
+
+
 v2.2.0: I/O & CLI
 -----------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ ipykernel
 
 # FOR TESTING
 asv
+flake8<5  # github.com/tholo/pytest-flake8/issues/87
 pytest
 coveralls
 pytest_cov


### PR DESCRIPTION
Problem: There is a failure in `test_transform.py::test_hankel` for MacOS/Windows CI; when using `scipy v1.9.0`. Not sure what is causing it.

Currently a dirty workaround: In the MacOS/Windows-CI we exclude `scipy!=1.9.0`. If it will be resolved upstream, good. If not, it will resurface with any new SciPy version.

Also restricting currently `flake8<5`, due to incompatibility with `pytest-flake8`.